### PR TITLE
fix CORS config typo

### DIFF
--- a/java-chassis-reference/zh_CN/general-development/CORS.md
+++ b/java-chassis-reference/zh_CN/general-development/CORS.md
@@ -31,8 +31,6 @@ servicecomb:
     enabled: true
     origin: "*"
     allowCredentials: false
-    allowedHeaders: Header-abc, Header-def
-    allowdedMethod: GET,PUT,DELETE,POST
-    exposedHeaders: Header-abc, Header-def
+    allowedMethod: PUT,DELETE
     maxAge: 3600
 ```


### PR DESCRIPTION
修复示例中allowedMethod配置项的拼写错误，并删除两项可能误导用户的配置例子